### PR TITLE
Add support for multi-architecture builds and docker image

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,5 +15,19 @@ jobs:
       run: go list -json -deps ./... > go.list
     - uses: sonatype-nexus-community/nancy-github-action@main
     - run: make test
+    - run: make build-all
+    - uses: docker/login-action@v3
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - uses: docker/setup-buildx-action@v3
-    - run: make docker-all
+    - uses: docker/build-push-action@v6
+      with:
+        push: true
+        tags: theo01/mcp-time:${{ github.ref }}
+        file: docker/Dockerfile
+        platforms:
+          - linux/amd64
+          - linux/arm64
+          - darwin/amd64
+          - darwin/arm64

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -17,13 +17,13 @@ jobs:
     - run: make test
     - run: make build-all
     - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            theo01/mcp-time
-          tags: |
-            type=ref,event=branch
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          theo01/mcp-time
+        tags: |
+          type=ref,event=branch
     - uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -54,9 +54,3 @@ jobs:
     steps:
       - uses: docker/setup-docker-action@v4
       - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version
-  test-macos-arm64:
-    needs: build
-    runs-on: macos-15
-    steps:
-      - uses: docker/setup-docker-action@v4
-      - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
@@ -31,3 +31,23 @@ jobs:
           - linux/arm64
           - darwin/amd64
           - darwin/arm64
+  test-linux-amd64:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version
+  test-linux-arm64:
+    needs: build
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version
+  test-macos-amd64:
+    needs: build
+    runs-on: macos-13
+    steps:
+      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version
+  test-macos-arm64:
+    needs: build
+    runs-on: macos-15
+    steps:
+      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,7 +37,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         context: .
         file: docker/Dockerfile
-        platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
+        platforms: linux/amd64,linux/arm64
   test-linux-amd64:
     needs: build
     runs-on: ubuntu-24.04
@@ -48,12 +48,4 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version
-  test-macos-amd64:
-    needs: build
-    runs-on: macos-13
-    steps:
-      - name: Install docker
-        run: |
-          brew install colima docker && \
-            colima start
-      - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version
+  

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,7 +3,7 @@ name: go
 on: [pull_request, push]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -15,4 +15,5 @@ jobs:
       run: go list -json -deps ./... > go.list
     - uses: sonatype-nexus-community/nancy-github-action@main
     - run: make test
-    - run: make build
+    - uses: docker/setup-buildx-action@v3
+    - run: make docker-all

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,7 +23,7 @@ jobs:
         images: |
           theo01/mcp-time
         tags: |
-          type=ref,event=branch
+          type=ref,event=push
     - uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,6 +16,14 @@ jobs:
     - uses: sonatype-nexus-community/nancy-github-action@main
     - run: make test
     - run: make build-all
+    - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            theo01/mcp-time
+          tags: |
+            type=ref,event=branch
     - uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -24,7 +32,7 @@ jobs:
     - uses: docker/build-push-action@v6
       with:
         push: true
-        tags: theo01/mcp-time:${{ github.ref_name }}
+        tags: ${{ steps.meta.outputs.tags }}
         context: .
         file: docker/Dockerfile
         platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -52,5 +52,8 @@ jobs:
     needs: build
     runs-on: macos-13
     steps:
-      - uses: docker/setup-docker-action@v4
+      - name: Install docker
+        run: |
+          brew install colima docker && \
+            colima start
       - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -24,26 +24,26 @@ jobs:
     - uses: docker/build-push-action@v6
       with:
         push: true
-        tags: theo01/mcp-time:${{ github.ref }}
+        tags: theo01/mcp-time:${{ github.ref_name }}
         file: docker/Dockerfile
         platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
   test-linux-amd64:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version
+      - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version
   test-linux-arm64:
     needs: build
     runs-on: ubuntu-24.04-arm
     steps:
-      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version
+      - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version
   test-macos-amd64:
     needs: build
     runs-on: macos-13
     steps:
-      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version
+      - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version
   test-macos-arm64:
     needs: build
     runs-on: macos-15
     steps:
-      - run: docker run --rm theo01/mcp-time:${{ github.ref }} --version
+      - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,6 +1,6 @@
 name: go
 
-on: [pull_request, push]
+on: push
 
 jobs:
   build:
@@ -16,6 +16,8 @@ jobs:
     - uses: sonatype-nexus-community/nancy-github-action@main
     - run: make test
     - run: make build-all
+      env:
+        BUILD_USER: github-action
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
@@ -23,7 +25,7 @@ jobs:
         images: |
           theo01/mcp-time
         tags: |
-          type=ref,event=push
+          type=ref,event=branch
     - uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -50,9 +52,11 @@ jobs:
     needs: build
     runs-on: macos-13
     steps:
+      - uses: docker/setup-docker-action@v4
       - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version
   test-macos-arm64:
     needs: build
     runs-on: macos-15
     steps:
+      - uses: docker/setup-docker-action@v4
       - run: docker run --rm theo01/mcp-time:${{ github.ref_name }} --version

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -26,11 +26,7 @@ jobs:
         push: true
         tags: theo01/mcp-time:${{ github.ref }}
         file: docker/Dockerfile
-        platforms:
-          - linux/amd64
-          - linux/arm64
-          - darwin/amd64
-          - darwin/arm64
+        platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
   test-linux-amd64:
     needs: build
     runs-on: ubuntu-24.04

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         push: true
         tags: theo01/mcp-time:${{ github.ref_name }}
+        context: .
         file: docker/Dockerfile
         platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
   test-linux-amd64:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,17 +15,17 @@ jobs:
         go-version: stable
     - run: make build-all
     - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            name/app
-            ghcr.io/username/app
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          name/app
+          ghcr.io/username/app
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=branch
+          type=semver,pattern={{version}}
     - uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
         push: true
         tags: theo01/mcp-time:latest,theo01/mcp-time:${{ github.ref_name }}
         file: docker/Dockerfile
+        context: .
         platforms:
           - linux/amd64
           - linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.24.0'
+        go-version: stable
     - uses: docker/setup-buildx-action@v3
     - run: make build-all
     - uses: docker/login-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
     - uses: docker/build-push-action@v6
       with:
         push: true
-        tags: theo01/mcp-time:latest,theo01/mcp-time:${{ github.ref }}
+        tags: theo01/mcp-time:latest,theo01/mcp-time:${{ github.ref_name }}
         file: docker/Dockerfile
         platforms:
           - linux/amd64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
       with:
         go-version: stable
     - run: make build-all
+      env:
+        BUILD_USER: github-action
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
@@ -49,4 +51,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BUILD_BRANCH: ${{ vars.BUILD_BRANCH }}
-        BUILD_USER: ${{ vars.BUILD_USER }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,18 +7,18 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
         go-version: stable
-    - uses: docker/setup-buildx-action@v3
     - run: make build-all
     - uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: docker/setup-buildx-action@v3
     - uses: docker/build-push-action@v6
       with:
         push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,11 +13,22 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '^1.24.0'
-    - name: dependencies
-      run: |
-        sudo apt-get install -y \
-          gcc-aarch64-linux-gnu \
-          g++-aarch64-linux-gnu
+    - uses: docker/setup-buildx-action@v3
+    - run: make build-all
+    - uses: docker/login-action@v3
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: docker/build-push-action@v6
+      with:
+        push: true
+        tags: theo01/mcp-time:latest,theo01/mcp-time:${{ github.ref }}
+        file: docker/Dockerfile
+        platforms:
+          - linux/amd64
+          - linux/arm64
+          - darwin/amd64
+          - darwin/arm64
     - uses: goreleaser/goreleaser-action@v6
       with:
         args: release --clean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,11 +39,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         file: docker/Dockerfile
         context: .
-        platforms:
-          - linux/amd64
-          - linux/arm64
-          - darwin/amd64
-          - darwin/arm64
+        platforms: linux/amd64,linux/arm64
     - uses: goreleaser/goreleaser-action@v6
       with:
         args: release --clean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,18 @@ jobs:
       with:
         go-version: stable
     - run: make build-all
+    - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            name/app
+            ghcr.io/username/app
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
     - uses: docker/login-action@v3
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -22,7 +34,7 @@ jobs:
     - uses: docker/build-push-action@v6
       with:
         push: true
-        tags: theo01/mcp-time:latest,theo01/mcp-time:${{ github.ref_name }}
+        tags: ${{ steps.meta.outputs.tags }}
         file: docker/Dockerfile
         context: .
         platforms:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           ghcr.io/username/app
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=ref,event=branch
+          type=raw,value=latest
           type=semver,pattern={{version}}
     - uses: docker/login-action@v3
       with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,36 +5,22 @@ before:
     - go mod tidy
 
 builds:
-  - main: ./cmd/mcp-time/
-    flags:
-    - -v
-    ldflags:
-    - -s -w
-    - -extldflags=-static
-    - -X github.com/prometheus/common/version.Version={{.Version}}
-    - -X github.com/prometheus/common/version.Revision={{.FullCommit}}
-    - -X github.com/prometheus/common/version.Branch={{.Branch}}
-    - -X github.com/prometheus/common/version.BuildUser=goreleaser
-    - -X github.com/prometheus/common/version.BuildDate={{.Date}}
+  - builder: prebuilt
     env:
       - CGO_ENABLED=1
+      - BUILD_USER=goreleaser
     goos:
-      - darwin
       - linux
+      - darwin
     goarch:
       - amd64
       - arm64
-    overrides:
-      - goos: linux
-        goarch: arm64
-        env:
-          - CGO_ENABLED=1
-          - CC=aarch64-linux-gnu-gcc
-          - CXX=aarch64-linux-gnu-g++
-    binary: bin/mcp-time
+    prebuilt:
+      path: build/mcp-time.{{ .Os }}-{{ .Arch }}
+    binary: bin/mybin
 
 archives:
-  - format: binary
+  - formats: ["binary"]
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,9 +6,6 @@ before:
 
 builds:
   - builder: prebuilt
-    env:
-      - CGO_ENABLED=1
-      - BUILD_USER=goreleaser
     goos:
       - linux
       - darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
-[Unreleased]: https://github.com/TheoBrigitte/mcp-time/tree/main
+### Added
+
+- Add support for multi-arch build and docker image
+
+## 0.1.0 - 2025-07-10
+
+### Added
+
+- Initial version
+
+[Unreleased]: https://github.com/TheoBrigitte/mcp-time/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/TheoBrigitte/mcp-time/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build-all: build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-a
 install: build ## Install the binary to ~/.local/bin
 	@printf "$(CYAN)Installing binary to ~/.local/bin...$(RESET)\n"
 	@mkdir -p ~/.local/bin
-	cp $(BUILD_DIR)/$(PROJECT_NAME).$(GOARCH) ~/.local/bin/$(PROJECT_NAME)
+	cp $(BUILD_DIR)/$(PROJECT_NAME).$(GOOS)-$(GOARCH) ~/.local/bin/$(PROJECT_NAME)
 	chmod +x ~/.local/bin/$(PROJECT_NAME)
 	@printf "$(GREEN)Binary installed to ~/.local/bin/$(PROJECT_NAME)$(RESET)\n"
 
@@ -79,7 +79,7 @@ docker: build ## Build the Docker image
 .PHONY: docker
 docker-all: build-all ## Build the Docker image for all architectures
 	@printf "$(CYAN)Building Docker image...$(RESET)\n"
-	docker buildx build --platform linux/amd64,linux/arm64,darwin/amd64,darwin/arm64 -f $(DOCKER_FILE) -t $(PROJECT_NAME) .
+	docker buildx build --platform linux/amd64,linux/arm64 -f $(DOCKER_FILE) -t $(PROJECT_NAME) .
 	@printf "$(GREEN)Docker image built successfully$(RESET)\n"
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ RESET := \033[0m
 define build
 	@printf "$(CYAN)Building Go binary...$(RESET)\n"
 	mkdir -p $(BUILD_DIR)
-	GOOS=$(1) GOARCH=$(2) go build -v -o ./$(BUILD_DIR)/$(PROJECT_NAME).$(1)-$(2) -ldflags=" \
+	GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -v -o ./$(BUILD_DIR)/$(PROJECT_NAME).$(1)-$(2) -ldflags=" \
 	-s -w \
 	-X main.Name=$(PROJECT_NAME) \
 	-X github.com/prometheus/common/version.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The Time MCP Server is a [Model Context Protocol (MCP)](https://github.com/model
 ### Using Docker
 
 ```bash
-docker run mcp-time
+docker pull theo01/mcp-time:latest
 ```
 
 ### Using Go Install

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ The Time MCP Server is a [Model Context Protocol (MCP)](https://github.com/model
 
 ## Installation
 
+### Using Docker
+
+```bash
+docker run mcp-time
+```
+
+### Using Go Install
+
+```bash
+go install github.com/TheoBrigitte/mcp-time/cmd/mcp-time@latest
+```
+
+This will install the `mcp-time` binary in your `$GOPATH/bin` directory, which should be in your `$PATH`.
+
 ### Building from Source
 
 ```bash
@@ -41,13 +55,7 @@ cd mcp-time
 make install
 ```
 
-This will build and install the `mcp-time` binary in the `~/.local/bin` directory, which should be in your `PATH`.
-
-### Using Go Install
-
-```bash
-go install github.com/TheoBrigitte/mcp-time/cmd/mcp-time@latest
-```
+This will build and install the `mcp-time` binary in the `~/.local/bin` directory, which should be in your `$PATH`.
 
 ## Integration with AI Assistants
 
@@ -55,11 +63,26 @@ This MCP server can be integrated with various AI assistants that support the Mo
 
 ### Example MCP Client Configuration
 
+- With Docker
+
 ```json
 {
   "servers": {
     "time": {
-      "command": "/path/to/mcp-time"
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "theo01/mcp-time:latest"]
+    }
+  }
+}
+```
+
+- With the binary installed
+
+```json
+{
+  "servers": {
+    "time": {
+      "command": "mcp-time"
     }
   }
 }
@@ -105,13 +128,15 @@ Flags:
 
 ## Available Tools
 
-### `current_time`
+### `relative_time`
 
-Get the current time.
+Get a time based on a relative natural language expression.
 
 **Parameters:**
-- `format` (optional): The output format for the time. Can be a predefined format (e.g., `RFC3339`, `Kitchen`) or a custom Go layout.
-- `timezone` (optional): The target timezone in IANA format (e.g., `America/New_York`). Defaults to UTC.
+- `text` (required): The natural language expression (e.g., `yesterday`, `5 minutes ago`, `next month`).
+- `time` (optional): A reference time for the relative expression. Defaults to current time.
+- `timezone` (optional): The target timezone for the output.
+- `format` (optional): The output format for the time.
 
 ### `convert_timezone`
 
@@ -123,6 +148,14 @@ Convert a given time between timezones.
 - `output_timezone` (optional): The target timezone for the output.
 - `format` (optional): The output format for the time.
 
+### `current_time`
+
+Get the current time.
+
+**Parameters:**
+- `format` (optional): The output format for the time. Can be a predefined format (e.g., `RFC3339`, `Kitchen`) or a custom Go layout.
+- `timezone` (optional): The target timezone in IANA format (e.g., `America/New_York`). Defaults to UTC.
+
 ### `add_time`
 
 Add or subtract a duration to a given time.
@@ -130,16 +163,6 @@ Add or subtract a duration to a given time.
 **Parameters:**
 - `time` (required): The input time string.
 - `duration` (required): The duration to add or subtract (e.g., `2h30m`, `-1h`).
-- `timezone` (optional): The target timezone for the output.
-- `format` (optional): The output format for the time.
-
-### `relative_time`
-
-Get a time based on a relative natural language expression.
-
-**Parameters:**
-- `text` (required): The natural language expression (e.g., `yesterday`, `5 minutes ago`, `next month`).
-- `time` (optional): A reference time for the relative expression. Defaults to current time.
 - `timezone` (optional): The target timezone for the output.
 - `format` (optional): The output format for the time.
 

--- a/README.md
+++ b/README.md
@@ -27,27 +27,53 @@ The Time MCP Server is a [Model Context Protocol (MCP)](https://github.com/model
 - **MCP Compliance**: Fully compatible with the Model Context Protocol standard.
 - **Multiple Transports**: Can be run using `stdio` for simple integrations or as an `HTTP stream` server for network access.
 
-## Prerequisites
-
-- Go 1.24.2 or later
-
 ## Installation
+
+This MCP server can be integrated with various AI assistants that support the Model Context Protocol.
 
 ### Using Docker
 
-```bash
-docker pull theo01/mcp-time:latest
+```json
+{
+  "mcpServers": {
+    "time": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "theo01/mcp-time:latest"
+      ]
+    }
+  }
+}
 ```
 
-### Using Go Install
+### Using binary
+
+```json
+{
+  "mcpServers": {
+    "time": {
+      "command": "mcp-time"
+    }
+  }
+}
+```
+
+#### Install from releases
+
+You can download the latest binary from the [releases page](https://github.com/TheoBrigitte/mcp-time/releases).
+
+#### Install with Go
 
 ```bash
 go install github.com/TheoBrigitte/mcp-time/cmd/mcp-time@latest
 ```
 
-This will install the `mcp-time` binary in your `$GOPATH/bin` directory, which should be in your `$PATH`.
+This will install the `mcp-time` binary in your `$GOPATH/bin` directory.
 
-### Building from Source
+#### Building from Source
 
 ```bash
 git clone https://github.com/TheoBrigitte/mcp-time.git
@@ -55,38 +81,7 @@ cd mcp-time
 make install
 ```
 
-This will build and install the `mcp-time` binary in the `~/.local/bin` directory, which should be in your `$PATH`.
-
-## Integration with AI Assistants
-
-This MCP server can be integrated with various AI assistants that support the Model Context Protocol.
-
-### Example MCP Client Configuration
-
-- With Docker
-
-```json
-{
-  "servers": {
-    "time": {
-      "command": "docker",
-      "args": ["run", "--rm", "-i", "theo01/mcp-time:latest"]
-    }
-  }
-}
-```
-
-- With the binary installed
-
-```json
-{
-  "servers": {
-    "time": {
-      "command": "mcp-time"
-    }
-  }
-}
-```
+This will build and install the `mcp-time` binary in the `~/.local/bin` directory.
 
 ## Usage
 
@@ -108,11 +103,8 @@ mcp-time --transport stream --address "http://localhost:8080/mcp"
 
 The server supports several command-line options for more advanced configurations:
 
-```bash
-mcp-time --help
 ```
-
-```
+$ mcp-time --help
 An MCP (Model Context Protocol) server which provides utilities to work with time and dates.
 
 Usage:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM --platform=$BUILDPLATFORM scratch
+ARG TARGETOS
+ARG TARGETARCH
+
+ADD build/mcp-time.${TARGETOS}-${TARGETARCH} /app/mcp-time
+
+ENTRYPOINT ["/app/mcp-time"]


### PR DESCRIPTION
- Adding support for multi-architecture Go builds:
  - linux/amd64
  - linux/arm64
  - darwin/amd64
  - darwin/arm64
- Adding support for building multi-architecture Docker images
- Update CI jobs to build and push multi-arch images and use pre-built binaries from Makefile