### PR TITLE
Fix missing tzdata in docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing tzdata in docker image
+
 ## [0.3.1] - 2025-07-24
 
 ### Added

--- a/cmd/mcp-time/cmd.go
+++ b/cmd/mcp-time/cmd.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	_ "time/tzdata"
 
 	"github.com/prometheus/common/version"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Requesting a different timezone than UTC when using the docker image leads to the following error:

```
invalid_timezone: Invalid IANA timezone name: America/New_York
```

This PR fixes this by embedding the tzdata directly within the Go binary.

Closes #4